### PR TITLE
Increase scaling range, small scaling bugfix

### DIFF
--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -10,7 +10,7 @@ interface Props {
 const ButtonGroup = ({ scale, setScale }: Props) => {
 	const incrementScale = (increment: number) => {
 		const newScale = Math.round((scale + increment) * 10) / 10;
-		if (newScale <= 2 && newScale >= 1) {
+		if (newScale <= 5.0 && newScale >= 0.5) {
 			setScale(newScale);
 		}
 	};

--- a/src/hooks/useTextLayer.ts
+++ b/src/hooks/useTextLayer.ts
@@ -11,10 +11,10 @@ import {
 
 const useTextLayer = (scale: number, context: CanvasRenderingContext2D, initialTextLayer?: Array<TextLayerItem>) => {
 	const [textLayer, setTextLayer] = useState<Array<TextLayerItem> | null>(initialTextLayer || null);
-	const [baseScale, setBaseScale] = useState(scale);
+	const [baseScale, setBaseScale] = useState(1.5);
 
 	useEffect(() => {
-		if (textLayer && baseScale !== scale) {
+		if (textLayer && context && baseScale !== scale) {
 			const rescaledWords = textLayer.map((word) => {
 				const coords = recalculateBoundingBox(word.coords, baseScale, scale);
 				const fontSize = calculateFontSize(coords.width, coords.height, word.text);


### PR DESCRIPTION
I have a use-case where I'm using Annotator and providing it PDFs with pre-defined text maps/OCR and labels.

As I update the Annotator with new PDFs, it was resetting the zoom index, so I hard-coded it in the text layer to match the default initialScale value (as well as an extra check for context, it was null sometimes and breaking the app)

My PDFs are also huge, and need a wider zoom range. I don't see the issue with increasing the zooming scale range, it works perfectly. I wouldn't apply tesseract with it super zoomed in, but since the default scale is 1.5, that shouldn't be a problem.

I think this merge would be nice to have, otherwise I have to live with monkey-patched files in node_modules lol
